### PR TITLE
Add case-insensitivity for char-val nodes (Issue #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,4 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+/AbnfToAntlr.Web/Properties/PublishProfiles

--- a/AbnfToAntlr.Common/Properties/AssemblyInfo.cs
+++ b/AbnfToAntlr.Common/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Robert Pinchbeck")]
 [assembly: AssemblyProduct("AbnfToAntlr")]
-[assembly: AssemblyCopyright("Copyright © 2012-2017")]
+[assembly: AssemblyCopyright("Copyright © 2012-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -53,5 +53,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/AbnfToAntlr.Common/TreeVisitor_OutputTranslation_Direct.cs
+++ b/AbnfToAntlr.Common/TreeVisitor_OutputTranslation_Direct.cs
@@ -1,6 +1,6 @@
 ﻿/*
 
-    Copyright 2012-2013 Robert Pinchbeck
+    Copyright 2012-2018 Robert Pinchbeck
   
     This file is part of AbnfToAntlr.
 
@@ -67,9 +67,50 @@ namespace AbnfToAntlr.Common
             text = text.Replace(@"\", @"\\"); // escape forwardslashes (order matters, this must be done before escaping anything else)
             text = text.Replace(@"'", @"\'"); // escape apostrophes
 
-            Write("'");
-            Write(text);
-            Write("'");
+            var length = text.Length;
+
+            if (length > 1)
+            {
+                Write("(");
+            }
+            for (int index = 0; index < length; index++)
+            {
+                if (index > 0)
+                {
+                    Write(" ");
+                }
+
+                var upperCharacter = char.ToUpperInvariant(text[index]);
+                var lowerCharacter = char.ToLowerInvariant(text[index]);
+
+                if (upperCharacter == lowerCharacter)
+                {
+                    Write("'");
+                    Write(upperCharacter.ToString());
+                    Write("'");
+                }
+                else
+                {
+                    Write("(");
+
+                    Write("'");
+                    Write(upperCharacter.ToString());
+                    Write("'");
+
+                    Write(" | ");
+
+                    Write("'");
+                    Write(lowerCharacter.ToString());
+                    Write("'");
+
+                    Write(")");
+                }
+            }
+
+            if (length > 1)
+            {
+                Write(")");
+            }
         }
 
         /// <summary>

--- a/AbnfToAntlr.Common/TreeVisitor_OutputTranslation_Indirect.cs
+++ b/AbnfToAntlr.Common/TreeVisitor_OutputTranslation_Indirect.cs
@@ -1,6 +1,6 @@
 ﻿/*
 
-    Copyright 2012-2013 Robert Pinchbeck
+    Copyright 2012-2018 Robert Pinchbeck
   
     This file is part of AbnfToAntlr.
 
@@ -39,8 +39,8 @@ namespace AbnfToAntlr.Common
 
         public TreeVisitor_OutputTranslation_Indirect(ITokenStream tokens, System.IO.TextWriter writer, Dictionary<char, NamedCharacter> distinctCharacters, INamedCharacterLookup lookup)
             : base(tokens, writer, lookup)
-        { 
-            _distinctCharacters =distinctCharacters;
+        {
+            _distinctCharacters = distinctCharacters;
         }
 
         /// <summary>
@@ -68,8 +68,24 @@ namespace AbnfToAntlr.Common
                     Write(" ");
                 }
 
-                var namedCharacter = _lookup.GetNamedCharacter(text[index]);
-                Write(namedCharacter.Name);
+                var upperCharacter = char.ToUpperInvariant(text[index]);
+                var lowerCharacter = char.ToLowerInvariant(text[index]);
+
+                var namedUpperCharacter = _lookup.GetNamedCharacter(upperCharacter);
+                var namedLowerCharacter = _lookup.GetNamedCharacter(lowerCharacter);
+
+                if (upperCharacter == lowerCharacter)
+                {
+                    Write(namedUpperCharacter.Name);
+                }
+                else
+                {
+                    Write("(");
+                    Write(namedUpperCharacter.Name);
+                    Write(" | ");
+                    Write(namedLowerCharacter.Name);
+                    Write(")");
+                }
             }
 
             if (length > 1)

--- a/AbnfToAntlr.Web/Default.aspx
+++ b/AbnfToAntlr.Web/Default.aspx
@@ -1,5 +1,5 @@
 ﻿<!--
-    Copyright 2012-2013 Robert Pinchbeck
+    Copyright 2012-2018 Robert Pinchbeck
   
     This file is part of AbnfToAntlr.
 
@@ -57,6 +57,7 @@
         <asp:TextBox ID="txtOutput" runat="server" TextMode="MultiLine" ReadOnly="True" Height="300" Width="100%" Wrap="False"></asp:TextBox>
         <br />
         <asp:TextBox ID="txtError" runat="server" ForeColor="Red" ReadOnly="True" TextMode="MultiLine" Width="100%"></asp:TextBox>
+        <h4>Version 1.5</h4>
     </form>
 </body>
 </html>

--- a/AbnfToAntlr.Web/Default.aspx.cs
+++ b/AbnfToAntlr.Web/Default.aspx.cs
@@ -1,6 +1,6 @@
 ﻿/*
 
-    Copyright 2012-2013 Robert Pinchbeck
+    Copyright 2012-2018 Robert Pinchbeck
   
     This file is part of AbnfToAntlr.
 

--- a/AbnfToAntlr.Web/Properties/AssemblyInfo.cs
+++ b/AbnfToAntlr.Web/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Robert Pinchbeck")]
 [assembly: AssemblyProduct("AbnfToAntlr")]
-[assembly: AssemblyCopyright("Copyright © 2012-2017")]
+[assembly: AssemblyCopyright("Copyright © 2012-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -52,5 +52,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/AbnfToAntlr.Web/copying.txt
+++ b/AbnfToAntlr.Web/copying.txt
@@ -1,4 +1,4 @@
-﻿Copyright 2012-2013 Robert Pinchbeck
+﻿Copyright 2012-2018 Robert Pinchbeck
 
 This file is part of AbnfToAntlr.
   

--- a/AbnfToAntlr/Copying.txt
+++ b/AbnfToAntlr/Copying.txt
@@ -1,4 +1,4 @@
-﻿Copyright 2013 Robert Pinchbeck
+﻿Copyright 2013-2018 Robert Pinchbeck
 
 This file is part of AbnfToAntlr.
   

--- a/AbnfToAntlr/Properties/AssemblyInfo.cs
+++ b/AbnfToAntlr/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Robert Pinchbeck")]
 [assembly: AssemblyProduct("AbnfToAntlr")]
-[assembly: AssemblyCopyright("Copyright © 2012 - 2017")]
+[assembly: AssemblyCopyright("Copyright © 2012 - 2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]


### PR DESCRIPTION
Add case-insensitivity for char-val nodes per https://tools.ietf.org/html/rfc5234#section-2.3 which states...

ABNF strings are case insensitive and the character set for these
      strings is US-ASCII.

   Hence:

         rulename = "abc"

   and:

         rulename = "aBc"

   will match "abc", "Abc", "aBc", "abC", "ABc", "aBC", "AbC", and
   "ABC".

      To specify a rule that is case sensitive, specify the characters
      individually.

   For example:

         rulename    =  %d97 %d98 %d99

   or

         rulename    =  %d97.98.99

   will match only the string that comprises only the lowercase
   characters, abc.


